### PR TITLE
Improve prompt configuration loading and add tests

### DIFF
--- a/myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/prompts.py
+++ b/myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/prompts.py
@@ -1,5 +1,9 @@
 # flake8: noqa
+import json
 from copy import deepcopy
+
+with open('myenv2/lib/python3.11/site-packages/langchain/chains/prompt_style_config.json') as config_file:
+    style_config = json.load(config_file)
 
 from langchain_core.prompts.few_shot import FewShotPromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate

--- a/myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/tests/test_prompts.py
+++ b/myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/tests/test_prompts.py
@@ -1,0 +1,22 @@
+import json
+import unittest
+from unittest.mock import mock_open, patch
+
+from langchain.chains.constitutional_ai.prompts import style_config
+
+
+class TestPromptConfigLoading(unittest.TestCase):
+
+    def test_successful_config_loading(self):
+        mock_config = {'key': 'value'}
+        with patch('builtins.open', mock_open(read_data=json.dumps(mock_config))), patch('json.load', return_value=mock_config):
+            from langchain.chains.constitutional_ai.prompts import style_config
+            self.assertEqual(style_config, mock_config)
+
+    def test_file_not_found_error(self):
+        with patch('builtins.open', side_effect=FileNotFoundError), self.assertRaises(FileNotFoundError):
+            from langchain.chains.constitutional_ai.prompts import style_config
+
+    def test_invalid_json_error(self):
+        with patch('builtins.open', mock_open(read_data='invalid JSON')), patch('json.load', side_effect=json.JSONDecodeError('Expecting value', '', 0)), self.assertRaises(json.JSONDecodeError):
+            from langchain.chains.constitutional_ai.prompts import style_config

--- a/myenv2/lib/python3.11/site-packages/langchain/chains/prompt_style_config.json
+++ b/myenv2/lib/python3.11/site-packages/langchain/chains/prompt_style_config.json
@@ -1,0 +1,25 @@
+{
+  "styles": [
+    {
+      "style": "concise",
+      "options": {
+        "use_gender_neutral_terms": true,
+        "detail_level": "low"
+      }
+    },
+    {
+      "style": "detailed",
+      "options": {
+        "use_gender_neutral_terms": false,
+        "detail_level": "high"
+      }
+    },
+    {
+      "style": "gender-neutral",
+      "options": {
+        "use_gender_neutral_terms": true,
+        "detail_level": "medium"
+      }
+    }
+  ]
+}

--- a/myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/prompt.py
+++ b/myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/prompt.py
@@ -1,5 +1,9 @@
 # flake8: noqa
+import json
 from langchain.chains.prompt_selector import ConditionalPromptSelector, is_chat_model
+
+with open('myenv2/lib/python3.11/site-packages/langchain/chains/prompt_style_config.json') as config_file:
+    style_config = json.load(config_file)
 from langchain_core.prompts.chat import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,

--- a/myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/tests/test_prompt.py
+++ b/myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/tests/test_prompt.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+from unittest.mock import patch
+
+
+class TestQAConfigLoading(unittest.TestCase):
+
+    @patch('builtins.open', new_callable=patch.mock_open, read_data='{"prompt_style": "concise"}')
+    @patch('json.load', return_value={"prompt_style": "concise"})
+    def test_successful_config_loading(self, mock_json_load, mock_open):
+        from langchain.chains.qa_generation.prompt import style_config
+        self.assertEqual(style_config, {"prompt_style": "concise"})
+
+    @patch('builtins.open', side_effect=FileNotFoundError)
+    def test_file_not_found_error(self, mock_open):
+        with self.assertRaises(FileNotFoundError):
+            from langchain.chains.qa_generation.prompt import style_config
+
+    @patch('builtins.open', new_callable=patch.mock_open, read_data='invalid JSON')
+    @patch('json.load', side_effect=json.JSONDecodeError('Expecting value', '', 0))
+    def test_invalid_json_error(self, mock_json_load, mock_open):
+        with self.assertRaises(json.JSONDecodeError):
+            from langchain.chains.qa_generation.prompt import style_config
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Refactored the prompt configuration loading to use a centralized JSON configuration file
- Added unit tests to ensure proper handling of successful, file not found, and invalid JSON errors during configuration loading
- Improved the overall robustness and maintainability of the prompt configuration system

## Files

### myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/prompts.py
**Title:** Load prompt style configuration from JSON file

**Changes Summary:**
- Loaded the prompt style configuration from a JSON file using the `json` module
- Stored the loaded configuration in the `style_config` variable

**Label:** enhancement

### myenv2/lib/python3.11/site-packages/langchain/chains/constitutional_ai/tests/test_prompts.py
**Title:** Add unit tests for prompt configuration loading

**Changes Summary:**
- Added a test suite to verify the prompt configuration loading
- Tested successful configuration loading, file not found error, and invalid JSON error scenarios

**Label:** tests

### myenv2/lib/python3.11/site-packages/langchain/chains/prompt_style_config.json
**Title:** Centralized prompt style configuration

**Changes Summary:**
- Added a new JSON file to store the prompt style configuration
- Defined three different prompt styles: 'concise', 'detailed', and 'gender-neutral'

**Label:** enhancement

### myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/prompt.py
**Title:** Load prompt style configuration from JSON file

**Changes Summary:**
- Loaded the prompt style configuration from the centralized JSON file using the `json` module
- Stored the loaded configuration in the `style_config` variable

**Label:** enhancement

### myenv2/lib/python3.11/site-packages/langchain/chains/qa_generation/tests/test_prompt.py
**Title:** Add unit tests for QA prompt configuration loading

**Changes Summary:**
- Added a test suite to verify the QA prompt configuration loading
- Tested successful configuration loading, file not found error, and invalid JSON error scenarios

**Label:** tests



===== Original PR title and description ============

**Original Title:** Sweep/the recent changes introduced to the lan

**Original Description:**
None
